### PR TITLE
Add closing tcl after/wait to clean up interpreter

### DIFF
--- a/t/call.t
+++ b/t/call.t
@@ -45,6 +45,9 @@ print "ok 10\n";
 my $v = 1;
 $i->call("after", 250, sub { print "ok 11\n"; $v++; });
 $i->call("vwait", \$v);
+
+$i->call("after", 3000, 'set var fafafa');
+$i->call("vwait", "var");
 print "not " unless $v == 2;
 print "ok 12\n";
 


### PR DESCRIPTION
This change patches the effects of a bug which appears when running
`t/call.t`, namely that at the end of the test, the process segfaults
causing the entire test run to fail.  It seems that by adding an extra Tcl
`after/wait` combination allows the interpreter process to be cleaned up
properly before (or maybe while) destroying the objects in Perl.  The
problem only manifests itself when using a Perl sub in a Tcl `after` call;
commenting out such code removes the segfault, which itself happens in
`XS_Tcl_DeleteCommand`, (more directly within `Tcl_DeleteCommand` on line
1559 of `Tcl.xs`).

The solution presented here was found by comparing the code in this file
with that in `t/disposal-subs.t` which also uses an `after/wait` step which
doesn't seem to add any value to the test (the disposal-subs test also
segfaults if the extra `after/wait` is removed), however does stop the code
from segfaulting.  It is also interesting to note that when running the
disposal-subs test with the `after/wait` commented out shows that the perl
code within the `::perl::` namespace of Tcl mounts up (there are 1004 such
code objects at the end of the disposal-stubs run).  It could be that
references aren't being cleaned up correctly, however it wasn't clear where
this was happening, hence this patch over the actual issue.  This change
makes the tests pass on perl versions 5.8 .. 5.22.
