### PR TITLE
Add initial Travis-CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+sudo: required
+
+language: perl
+
+perl:
+    - "5.22"
+    - "5.20"
+    - "5.18"
+    - "5.16"
+    - "5.14"
+    - "5.12"
+    - "5.10"
+    - "5.8"
+
+install:
+    - sudo aptitude install tcl-dev


### PR DESCRIPTION
Travis-CI (https://travis-ci.org) is a service providing free build and
continuous integration services to open source projects.  This file is the
configuration file for the service; one merely needs to allow Travis-CI
access to the GitHub repo so that pushes to the repository can be
automatically checked.
