### PR TITLE
Add and update strictures

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -1,11 +1,10 @@
-#!perl -w
-
 # before running this script make sure you have 'tclsh' in your path, 
 # and this 'tcl' distribution is required one.
 # FreeBSD users may want to modify name of tcl interpreter (this is
 # $tclsh variable below) as long as 'tclsh' does not work in their case
 
 use strict;
+use warnings;
 use Getopt::Long qw(GetOptions);
 use ExtUtils::MakeMaker;
 use Config;

--- a/Tcl.pm
+++ b/Tcl.pm
@@ -1,5 +1,8 @@
 package Tcl;
 
+use strict;
+use warnings;
+
 $Tcl::VERSION = '1.03';
 
 =head1 NAME

--- a/t/call.t
+++ b/t/call.t
@@ -3,6 +3,9 @@
 # Tests for the 'call' and 'icall' functions.
 #
 
+use strict;
+use warnings;
+
 use Tcl;
 
 $| = 1;

--- a/t/constants.t
+++ b/t/constants.t
@@ -1,6 +1,6 @@
-#!perl -w
-
 use strict;
+use warnings;
+
 use Test qw(plan ok);
 
 plan tests => 3;

--- a/t/createcmd.t
+++ b/t/createcmd.t
@@ -1,3 +1,6 @@
+use strict;
+use warnings;
+
 use Tcl;
 
 $| = 1;
@@ -22,7 +25,7 @@ sub bargone {
     print "ok $_[0]\n";
 }
 
-$i = new Tcl;
+my $i = Tcl->new;
 
 $i->CreateCommand("foo", \&foo, {OK => "ok"}, \&foogone);
 $i->CreateCommand("bar", \&bar, 4, \&bargone);

--- a/t/disposal-subs.t
+++ b/t/disposal-subs.t
@@ -1,5 +1,8 @@
 # see how CODE REFs are created and then freed
 
+use strict;
+use warnings;
+
 use Tcl;
 
 $| = 1;
@@ -11,8 +14,9 @@ my $int = Tcl->new;
 $int->call('after', 1000, sub {"foo, bar, fluffy\n";});
 
 my $q = 0;
+my $r;
 for (1 .. 1000) {
-    my $r = 'aaa';
+    $r = 'aaa';
     $int->call('after', 1000, sub {"*";});
     $int->call('after', 1000, sub {$r++;"$r#";});
 

--- a/t/eval.t
+++ b/t/eval.t
@@ -1,10 +1,13 @@
+use strict;
+use warnings;
+
 use Tcl;
 
 $| = 1;
 
 print "1..5\n";
 
-$i = new Tcl;
+my $i = new Tcl;
 $i->Eval(q(puts "ok 1"));
 ($a, $b) = $i->Eval(q(list 2 ok));
 print "$b $a\n";

--- a/t/export_to_tcl.t
+++ b/t/export_to_tcl.t
@@ -1,5 +1,8 @@
 # tests convenience sub export_to_tcl
 
+use strict;
+use warnings;
+
 use Test;
 BEGIN {plan tests=>4}
 use Tcl;

--- a/t/info.t
+++ b/t/info.t
@@ -1,6 +1,6 @@
-#!perl -w
-
 use strict;
+use warnings;
+
 use Test qw(plan ok);
 
 plan tests => 6;

--- a/t/result.t
+++ b/t/result.t
@@ -1,8 +1,13 @@
+use strict;
+use warnings;
+
 use Tcl;
 
 $| = 1;
 
 print "1..5\n";
+
+my $i;
 
 sub foo {
     my $interp = $_[1];
@@ -26,7 +31,7 @@ $i->CreateCommand("foo", \&foo);
 $i->Eval('if {[catch foo res]} {puts $res} else {puts "ok 2"}');
 
 $i->ResetResult();
-@qlist = qw(a{b  g\h  j{{k}  l}m{   \}n);
+my @qlist = qw(a{b  g\h  j{{k}  l}m{   \}n);
 foreach (@qlist) {
     $i->AppendElement($_);
 }
@@ -37,7 +42,7 @@ if ($i->result eq 'a\{b {g\h} j\{\{k\} l\}m\{ {\}n}') {
     print "not ok 3\n";
 }
 
-@qlistout = $i->SplitList($i->result);
+my @qlistout = $i->SplitList($i->result);
 if ("@qlistout" eq "@qlist") {
     print "ok 4\n";
 } else {

--- a/t/subclass.t
+++ b/t/subclass.t
@@ -1,6 +1,6 @@
-#!perl -w
-
 use strict;
+use warnings;
+
 use Test qw(plan ok);
 
 plan tests => 4;

--- a/t/trace.t
+++ b/t/trace.t
@@ -1,13 +1,16 @@
+use strict;
+use warnings;
+
 use Tcl;
 
 $| = 1;
 
 print "1..2\n";
 
-$i = new Tcl;
+my $i = new Tcl;
 
-tie $perlscalar, Tcl::Var, $i, "tclscalar";
-tie %perlhash, Tcl::Var, $i, "tclhash";
+tie my $perlscalar, 'Tcl::Var', $i, "tclscalar";
+tie my %perlhash, 'Tcl::Var', $i, "tclhash";
 
 $i->Eval('set tclscalar ok; set tclhash(key) 1');
 printf "%s %s\n", $perlscalar, $perlhash{"key"};

--- a/t/unicode.t
+++ b/t/unicode.t
@@ -1,5 +1,3 @@
-#!perl -w
-
 # Test the transfer of null and various unicode data through assorted APIs.
 # The \x{2030} is the permille sign.
 #
@@ -7,6 +5,8 @@
 # on what kind of locale it runs under.
 
 use strict;
+use warnings;
+
 use Test qw(plan ok);
 
 plan tests => 6;

--- a/t/var.t
+++ b/t/var.t
@@ -1,3 +1,6 @@
+use strict;
+use warnings;
+
 use Tcl;
 
 $| = 1;
@@ -12,7 +15,7 @@ sub foo {
     $interp->Eval('puts $four', Tcl::EVAL_GLOBAL);
 }
 
-$i = new Tcl;
+my $i = new Tcl;
 
 $i->SetVar("foo", "ok 1");
 $i->Eval('puts $foo');
@@ -33,8 +36,8 @@ baz
 EOT
 
 $i->Eval('set a(OK) ok; set a(five) 5');
-$ok = $i->GetVar2("a", "OK");
-$five = $i->GetVar2("a", "five");
+my $ok = $i->GetVar2("a", "OK");
+my $five = $i->GetVar2("a", "five");
 print "$ok $five\n";
 
 print defined($i->GetVar("nonesuch")) ? "not ok 6\n" : "ok 6\n";
@@ -47,7 +50,7 @@ if ($]>=5.006 && $i->GetVar("tcl_version")>=8.1) {
     }
     print "ok 7 # Unicode persistence during [SG]etVar\n";
     my $r;
-    tie $r, Tcl::Var, $i, "perl_r";
+    tie $r, 'Tcl::Var', $i, "perl_r";
     $r = "\x{abcd}\x{1234}";
     if ($r ne "\x{abcd}\x{1234}") {
 	print "not ";


### PR DESCRIPTION
Add `warnings` and `strict` pragmas to files missing these.  Also converted the `-w` flag to the `perl` binary in the shebang line to `warnings` pragmas as necessary, since this is currently accepted best practice.

This pull request is submitted in the hope that it will be useful.  Any questions and/or comments are most welcome!
