### PR TITLE
Use direct object syntax for new() method invocations

### DIFF
--- a/Tcl.pm
+++ b/Tcl.pm
@@ -796,7 +796,7 @@ An example:
   use strict;
   use Tcl;
   
-  my $int = new Tcl;
+  my $int = Tcl->new;
   
   $tcl::foo = 'qwerty';
   $int->export_to_tcl(subs_from=>'tcl',vars_from=>'tcl');

--- a/t/createcmd.t
+++ b/t/createcmd.t
@@ -22,7 +22,7 @@ sub bargone {
     print "ok $_[0]\n";
 }
 
-$i = new Tcl;
+$i = Tcl->new;
 
 $i->CreateCommand("foo", \&foo, {OK => "ok"}, \&foogone);
 $i->CreateCommand("bar", \&bar, 4, \&bargone);

--- a/t/eval.t
+++ b/t/eval.t
@@ -4,7 +4,7 @@ $| = 1;
 
 print "1..5\n";
 
-$i = new Tcl;
+$i = Tcl->new;
 $i->Eval(q(puts "ok 1"));
 ($a, $b) = $i->Eval(q(list 2 ok));
 print "$b $a\n";

--- a/t/export_to_tcl.t
+++ b/t/export_to_tcl.t
@@ -4,7 +4,7 @@ use Test;
 BEGIN {plan tests=>4}
 use Tcl;
 
-my $int = new Tcl;
+my $int = Tcl->new;
 
 $tcl::foo = $tcl::foo = 'qwerty';
 my $x = "some perl scalar var";

--- a/t/result.t
+++ b/t/result.t
@@ -10,7 +10,7 @@ sub foo {
     return undef;
 }
 
-$i = new Tcl;
+$i = Tcl->new;
 
 
 $i->Eval('expr 10 + 30');

--- a/t/trace.t
+++ b/t/trace.t
@@ -4,7 +4,7 @@ $| = 1;
 
 print "1..2\n";
 
-$i = new Tcl;
+$i = Tcl->new;
 
 tie $perlscalar, Tcl::Var, $i, "tclscalar";
 tie %perlhash, Tcl::Var, $i, "tclhash";

--- a/t/unicode.t
+++ b/t/unicode.t
@@ -13,7 +13,7 @@ plan tests => 6;
 
 use Tcl;
 
-my $int = new Tcl;
+my $int = Tcl->new;
 
 my $str = "This is a string\n";
 $str .= "This is a string containing NUL (\0) and some other controls (\a\r)\n";

--- a/t/var.t
+++ b/t/var.t
@@ -12,7 +12,7 @@ sub foo {
     $interp->Eval('puts $four', Tcl::EVAL_GLOBAL);
 }
 
-$i = new Tcl;
+$i = Tcl->new;
 
 $i->SetVar("foo", "ok 1");
 $i->Eval('puts $foo');


### PR DESCRIPTION
The Perl documentation discourages using indirect object syntax for object
instantiation (http://perldoc.perl.org/perlobj.html#Invoking-Class-Methods).
All affected calls have been updated in this commit and the relevant tests
pass.
