### PR TITLE
Tcl.xs: use `%ld` for `count` in format strings

### DIFF
--- a/Tcl.xs
+++ b/Tcl.xs
@@ -786,8 +786,8 @@ int Tcl_EvalInPerl(ClientData clientData, Tcl_Interp *interp,
     }
     else {
 	if (count != 1) {
-	    croak("Perl sub bound to Tcl proc returned %d args, expected 1",
-		    count);
+	    croak("Perl sub bound to Tcl proc returned %ld args, expected 1",
+		    (long)count);
 	}
 	sv = POPs; /* pop the undef off the stack */
 
@@ -866,8 +866,8 @@ int Tcl_PerlCallWrapper(ClientData clientData, Tcl_Interp *interp,
     }
     else {
 	if (count != 1) {
-	    croak("Perl sub bound to Tcl proc returned %d args, expected 1",
-		    count);
+	    croak("Perl sub bound to Tcl proc returned %ld args, expected 1",
+		    (long)count);
 	}
 	sv = POPs; /* pop the undef off the stack */
 


### PR DESCRIPTION
continuing from https://github.com/gisle/tcl.pm/pull/12#issuecomment-398592805:
> 2. cast occurrences of `count` to `int` when used in `croak()`; this hasn't been applied already. Nor did my compiler (clang) warn me about this.

My compiler didn't warn me likely because `I32` is already an `int` (i.e. `int`s are 32 bits) on my system whereas the reporter of the issue might have had 16-bit `int`s.

To prevent the compiler warning, the approach I slightly prefer over casting `count` to `int` (as in the initially proposed patch) would be to instead use the `%ld` format specifier (where `%ld` is `long` which is at least 32 bits). Though I wouldn't expect something to use ~2**15 args anyways.

After merging this, [ticket 78308](https://rt.cpan.org/Ticket/Display.html?id=78308) can probably be closed.