### PR TITLE
Tcl.xs: prevent compiler warning on Windows

### DIFF
--- a/Tcl.xs
+++ b/Tcl.xs
@@ -80,7 +80,7 @@ static char defaultLibraryDir[sizeof(LIB_RUNTIME_DIR)+200] = LIB_RUNTIME_DIR;
 #include <windows.h>
 #undef WIN32_LEAN_AND_MEAN
 #define dlopen(libname, flags)	LoadLibrary(libname)
-#define dlclose(path)		((void *) FreeLibrary((HMODULE) path))
+#define dlclose(path)		FreeLibrary((HMODULE) path)
 #define DLSYM(handle, symbol, type, proc) \
 	(proc = (type) GetProcAddress((HINSTANCE) handle, symbol))
 #define snprintf _snprintf


### PR DESCRIPTION
```
> gcc -c  -IC:\MagicSplat\include -s -O2 -DWIN32 -DWIN64 -DCONSERVATIVE -D__USE_MINGW_ANSI_STDIO -DPERL_TEXTMODE_SCRIPTS -DPERL_IMPLICIT_CONTEXT -DPERL_IMPLICIT_SYS 
-DUSE_PERLIO -fwrapv -fno-strict-aliasing -mms-bitfields -s -O2   -DVERSION=\"1.27\" -DXS_VERSION=\"1.27\"  "-IC:\STRAWB~1\perl\lib\CORE"  -DUSE_TCL_STUBS -DTCLSH_PATH="\"C:/MagicSplat/bin\"" -DLIB_RUNTIME_DIR=\"C:/MagicSplat/bin\" -DTCL_LIB_FILE=\"tcl86t.dll\" Tcl.c
Tcl.xs: In function 'XS_Tcl__Finalize':
Tcl.xs:83:25: warning: cast to pointer from integer of different size [-Wint-to-pointer-cast]
 #define dlclose(path)  ((void *) FreeLibrary((HMODULE) path))
                         ^
      dlclose(tclHandle);
      ^~~~~~~
```

`FreeLibrary()` [returns `BOOL`](https://docs.microsoft.com/en-us/windows/desktop/api/libloaderapi/nf-libloaderapi-freelibrary) ([aka `int`](https://docs.microsoft.com/en-us/windows/desktop/winprog/windows-data-types)), so casting to a pointer type will cause this warning. Even though the return values of `FreeLibrary()` and UNIX `dlclose()` are compatible types but carry different meanings, they are currently ignored by Tcl.xs anyways, so removing the cast seems enough to prevent this warning.

Alternatively, I might not understand why the cast was originally added (c24e7de) or is still desirable.