### PR TITLE
Tcl.xs: prevent compiler warning on Linux for i386

### DIFF
--- a/Tcl.xs
+++ b/Tcl.xs
@@ -1558,7 +1558,7 @@ Tcl_CreateCommand(interp,cmdName,cmdProc,clientData=&PL_sv_undef,deleteProc=&PL_
     CODE:
 	if (!initialized) { return; }
 	if (SvIOK(cmdProc))
-	    Tcl_CreateCommand(interp, cmdName, (Tcl_CmdProc *) SvIV(cmdProc),
+	    Tcl_CreateCommand(interp, cmdName, INT2PTR(Tcl_CmdProc *, SvIV(cmdProc)),
 			      INT2PTR(ClientData, SvIV(clientData)), NULL);
 	else {
 	    AV *av = (AV *) SvREFCNT_inc((SV *) newAV());


### PR DESCRIPTION
This change prevents a compiler warning I observed on Ubuntu 18.04 for i386 (32-bit Intel):

```
Tcl.xs: In function ‘XS_Tcl_CreateCommand’:
Tcl.xs:1561:41: warning: cast to pointer from integer of different size [-Wint-to-pointer-cast]
      Tcl_CreateCommand(interp, cmdName, (Tcl_CmdProc *) SvIV(cmdProc),
                                         ^
```