### PR TITLE
Tcl.xs: handle undef SVs in TclObjFromSv()

### DIFF
--- a/Tcl.xs
+++ b/Tcl.xs
@@ -663,7 +663,10 @@ TclObjFromSv(pTHX_ SV *sv)
     if (SvGMAGICAL(sv))
 	mg_get(sv);
 
-    if (SvROK(sv) && SvTYPE(SvRV(sv)) == SVt_PVAV &&
+    if (!SvOK(sv)) {
+	objPtr = Tcl_NewObj();
+    }
+    else if (SvROK(sv) && SvTYPE(SvRV(sv)) == SVt_PVAV &&
 	(!SvOBJECT(SvRV(sv)) || sv_isa(sv, "Tcl::List")))
     {
 	/*


### PR DESCRIPTION
See chrstphrchvz/perl-tcl-ptk#17: assigning `undef` to a widget textvariable should behave the same as assigning an empty string, but unlike Perl/Tk a `Use of uninitialized value in subroutine entry` warning is emitted for programs with `use warnings 'uninitialized'`.

The issue is due to something affecting Tcl::Var, which is what widget textvariables are tied to. A more general example:

```perl
use warnings 'uninitialized';
use strict;

use Tcl;

my $i = new Tcl;
$i->Init;

my $t = ';l;;gmlxzssaw';
tie $t, 'Tcl::Var', $i, 'tvar';

$t = undef;
```

The `STORE` implementation for Tcl::Var in Tcl.xs uses `TclObjFromSv()` without first checking `SvOK()` (i.e. to not pass it an `undef` SV). `TclObjFromSv()` has several cases for possible types of SVs, but not one specifically for `undef` SVs, and the existing fallback case uses `SvPV(sv, length)` without first checking `SvOK(sv)`, which causes the warning message to be emitted.

I would argue that this should be fixed by adding proper handling of `undef` SVs to `TclObjFromSv()`. Making it the first case checked could be ideal.