### PR TITLE
fix unqualified Tcl::TRACE_DELETECOMMAND()

### DIFF
--- a/Tcl.pm
+++ b/Tcl.pm
@@ -886,7 +886,7 @@ sub DESTROY {
     return unless ($tclname);
     if (defined $interp) {
       $interp->DeleteCommand($tclname);
-      print "TCL::TRACE_DELETECOMMAND: $interp -> ( $tclname )\n" if TRACE_DELETECOMMAND();
+      print "TCL::TRACE_DELETECOMMAND: $interp -> ( $tclname )\n" if Tcl::TRACE_DELETECOMMAND();
     }
 }
 


### PR DESCRIPTION
Avoid warning if `$^W` set or if Tcl.pm were to `use warnings 'misc'`:

```
	(in cleanup) Undefined subroutine &Tcl::Cmdbase::TRACE_DELETECOMMAND called at tcl.pm/blib/lib/Tcl.pm line 889 during global destruction.
```