### PR TITLE
Tcl::Var: allow iterating Tcl array containing element with empty string as its name

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -15,6 +15,7 @@ t/subclass.t		See if we can subclass Tcl
 t/trace.t		See if variable tarcing works
 t/unicode.t		some unicode tests
 t/var.t			See if access to/from Tcl variables works
+t/var2.t
 t/export_to_tcl.t	test convenience sub export_to_tcl
 t/disposal-subs.t	check if code refs destroyed and removed from tcl
 t/disposal-subs-a.t

--- a/Tcl.pm
+++ b/Tcl.pm
@@ -935,12 +935,11 @@ sub NEXTKEY {
 sub _nextElement {
     my $obj = shift;
     my ($interp, $varname, $flags) = @$obj;
-    my $r = $interp->invoke("array","nextelement",$varname,$arraystates{$varname});
-    if ($r eq '') {
+    unless ($interp->invoke('array','anymore',$varname,$arraystates{$varname})) {
 	delete $arraystates{$varname};
 	return undef;
     }
-    return $r;
+    return $interp->invoke('array','nextelement',$varname,$arraystates{$varname});
 }
 sub CLEAR {
     my $obj = shift;

--- a/Tcl.pm
+++ b/Tcl.pm
@@ -924,17 +924,16 @@ sub FIRSTKEY {
 	unless @{$obj} == 2 || @{$obj} == 3;
     my ($interp, $varname, $flags) = @$obj;
     $arraystates{$varname} = $interp->invoke("array","startsearch",$varname);
-    my $r = $interp->invoke("array","nextelement",$varname,$arraystates{$varname});
-    if ($r eq '') {
-	delete $arraystates{$varname};
-	return undef;
-    }
-    return $r;
+    return $obj->_nextElement(@_);
 }
 sub NEXTKEY {
     my $obj = shift;
     die "STORE Usage: objdata @{$obj} $#{$obj}, not 2 or 3 (@_)"
 	unless @{$obj} == 2 || @{$obj} == 3;
+    return $obj->_nextElement(@_);
+}
+sub _nextElement {
+    my $obj = shift;
     my ($interp, $varname, $flags) = @$obj;
     my $r = $interp->invoke("array","nextelement",$varname,$arraystates{$varname});
     if ($r eq '') {

--- a/t/var2.t
+++ b/t/var2.t
@@ -1,0 +1,30 @@
+# Check for correct iterating over hash tied to a Tcl array
+# containing an element with the empty string as its name
+use warnings;
+use strict;
+use Test;
+
+BEGIN {
+    $| = 1;
+    plan tests => 4;
+}
+
+use Tcl;
+
+my $i = new Tcl;
+$i->Init;
+
+tie my %h, 'Tcl::Var', $i, 'myarray';
+$i->Eval(<<'EOS');
+array set myarray {
+    a  1
+    {} 2
+    b  3
+}
+EOS
+
+my @k = sort keys(%h);
+ok(@k, 3, 'correct keys(%h) length');
+ok($k[0], '',  q/keys(%h) contains ''/);
+ok($k[1], 'a', q/keys(%h) contains 'a'/);
+ok($k[2], 'b', q/keys(%h) contains 'b'/);


### PR DESCRIPTION
Tcl::Var `FIRSTKEY`/`NEXTKEY` currently assume that receiving an empty string from `array nextelement …` means the last element name was already returned, which does not accommodate a Tcl array containing an element with the empty string as its name. I suggest instead checking [`array anymore …`](https://www.tcl.tk/man/tcl/TclCmd/array.htm#M5) to tell whether there are additional element names to return.