### PR TITLE
Improve Tcl 8.7/9.0 readiness, `const` usage

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -26,6 +26,7 @@ t/disposal-subs-e.t
 t/disposal-subs-f.t
 t/memleak-a.t
 t/set-callback.t
+t/svfromtclobj.t
 typemap			Tcl extension types
 tclcfg.tcl		Tcl script to discover TCL installation options
 tcl-core/aix/libtclstub8.4.a

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -178,7 +178,7 @@ if (defined($libpath) && defined($incpath)) {
 
 	my $tclver = $tclcfg{tcl_version};
 
-	if ($tclcfg{tcl_library} =~ /^(.*)[\\\/]lib[\\\/]/) {
+	if ($tclcfg{tcl_library} =~ /^(.*)[\\\/]lib(?:[\\\/]|$)/) {
 	    $libpath = "-L$1/lib";
 	    $incpath = "-I$1/include";
 	    $defs .= " -DLIB_RUNTIME_DIR=\\\"$1/lib\\\"" if $usestubs;

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -40,7 +40,7 @@ sub _die ($) {
 my $tclsh_default = 'tclsh';
 # for FreeBSD users, try to guess their name for tclsh; see ticket 6086
 if ($^O eq 'freebsd') {
-    for my $ver (qw(8.9 8.8 8.7 8.6 8.5 8.4 8.3 8.2 8.1 8.0)) {
+    for my $ver (qw(9.0 8.7 8.6 8.5 8.4 8.3 8.2 8.1 8.0)) {
        system "which tclsh$ver >/dev/null 2>&1";
        if ($? == 0) {
 	    $tclsh_default = "tclsh$ver"; # ok will use that as default

--- a/Tcl.pm
+++ b/Tcl.pm
@@ -375,6 +375,10 @@ behaves as in I<SetVar> above.
 Unsets the element VARNAME1(VARNAME2) of a Tcl array.
 The optional argument FLAGS behaves as in I<SetVar> above.
 
+=item $interp->InterpDeleted ()
+
+See Tcl C API documentation for I<Tcl_InterpDeleted>().
+
 =back
 
 =head2 Linking Perl and Tcl variables

--- a/Tcl.xs
+++ b/Tcl.xs
@@ -19,11 +19,6 @@
 #endif
 
 /*
- * Until we update for 8.4 CONST-ness
- */
-#define USE_NON_CONST
-
-/*
  * Both Perl and Tcl use these macros
  */
 #undef STRINGIFY
@@ -399,7 +394,7 @@ NpInitialize(pTHX_ SV *X)
      * Variable initstubs have to be declared as volatile to prevent
      * compiler optimizing it out.
      */
-    static CONST char *(*volatile initstubs)(Tcl_Interp *, CONST char *, int)
+    static const char *(*volatile initstubs)(Tcl_Interp *, const char *, int)
 	= Tcl_InitStubs;
     char dllFilename[MAX_PATH];
     dllFilename[0] = '\0';
@@ -495,7 +490,7 @@ NpInitialize(pTHX_ SV *X)
 	}
     }
     if (tclKit_AppInit(g_Interp) != TCL_OK) {
-	CONST84 char *msg = Tcl_GetVar(g_Interp, "errorInfo", TCL_GLOBAL_ONLY);
+	const char *msg = Tcl_GetVar(g_Interp, "errorInfo", TCL_GLOBAL_ONLY);
 	warn("Failed to initialize Tcl with %s:\n%s",
 		(tclKit_AppInit == Tcl_Init) ? "Tcl_Init" : "TclKit_AppInit",
 		msg);
@@ -532,9 +527,9 @@ check_refcounts(Tcl_Obj *objPtr) {
 #endif
 
 static int
-has_highbit(CONST char *s, int len)
+has_highbit(const char *s, int len)
 {
-    CONST char *e = s + len;
+    const char *e = s + len;
     while (s < e) {
 	if (*s++ & 0x80)
 	    return 1;
@@ -783,7 +778,7 @@ TclObjFromSv(pTHX_ SV *sv)
 }
 
 int Tcl_EvalInPerl(ClientData clientData, Tcl_Interp *interp,
-	int objc, Tcl_Obj *CONST objv[])
+	int objc, Tcl_Obj *const objv[])
 {
     dTHX; /* fetch context */
     dSP;
@@ -840,7 +835,7 @@ int Tcl_EvalInPerl(ClientData clientData, Tcl_Interp *interp,
 }
 
 int Tcl_PerlCallWrapper(ClientData clientData, Tcl_Interp *interp,
-	int objc, Tcl_Obj *CONST objv[])
+	int objc, Tcl_Obj *const objv[])
 {
     dTHX; /* fetch context */
     dSP;
@@ -1208,7 +1203,7 @@ Tcl_invoke(interp, sv, ...)
 #define NUM_OBJS 16
 	    Tcl_Obj     *baseobjv[NUM_OBJS];
 	    Tcl_Obj    **objv = baseobjv;
-	    char        *cmdName;
+	    const char  *cmdName;
 	    int          objc, i, result;
 	    STRLEN       length;
 	    Tcl_CmdInfo	 cmdinfo;
@@ -1275,11 +1270,11 @@ Tcl_invoke(interp, sv, ...)
 		 * prepare string arguments into argv (1st is already done)
 		 * and call found procedure
 		 */
-		char  *baseargv[NUM_OBJS];
-		char **argv = baseargv;
+		const char  *baseargv[NUM_OBJS];
+		const char **argv = baseargv;
 
 		if (objc > NUM_OBJS) {
-		    New(666, argv, objc, char *);
+		    New(666, argv, objc, const char *);
 		}
 
 		argv[0] = cmdName;
@@ -1632,8 +1627,8 @@ Tcl_SplitList(interp, str)
 	Tcl		interp
 	char *		str
 	int		argc = NO_INIT
-	char **		argv = NO_INIT
-	char **		tofree = NO_INIT
+	const char **	argv = NO_INIT
+	const char **	tofree = NO_INIT
     PPCODE:
 	if (Tcl_SplitList(interp, str, &argc, &argv) == TCL_OK)
 	{

--- a/Tcl.xs
+++ b/Tcl.xs
@@ -18,12 +18,6 @@
 #define DEBUG_REFCOUNTS 0
 #endif
 
-/*
- * Both Perl and Tcl use these macros
- */
-#undef STRINGIFY
-#undef JOIN
-
 #include <tcl.h>
 
 #ifdef USE_TCL_STUBS

--- a/Tcl.xs
+++ b/Tcl.xs
@@ -165,13 +165,13 @@ extern Tcl_PackageInitProc Blt_Init, Blt_SafeInit;
  * These may not exist - guard against NULL result.
  */
 
-static Tcl_ObjType *tclBooleanTypePtr = NULL;
-static Tcl_ObjType *tclByteArrayTypePtr = NULL;
-static Tcl_ObjType *tclDoubleTypePtr = NULL;
-static Tcl_ObjType *tclIntTypePtr = NULL;
-static Tcl_ObjType *tclListTypePtr = NULL;
-static Tcl_ObjType *tclStringTypePtr = NULL;
-static Tcl_ObjType *tclWideIntTypePtr = NULL;
+static const Tcl_ObjType *tclBooleanTypePtr = NULL;
+static const Tcl_ObjType *tclByteArrayTypePtr = NULL;
+static const Tcl_ObjType *tclDoubleTypePtr = NULL;
+static const Tcl_ObjType *tclIntTypePtr = NULL;
+static const Tcl_ObjType *tclListTypePtr = NULL;
+static const Tcl_ObjType *tclStringTypePtr = NULL;
+static const Tcl_ObjType *tclWideIntTypePtr = NULL;
 
 /*
  * This tells us whether Tcl is in a "callable" state.  Set to 1 in BOOT

--- a/Tcl.xs
+++ b/Tcl.xs
@@ -547,7 +547,7 @@ SvFromTclObj(pTHX_ Tcl_Obj *objPtr)
 {
     SV *sv;
     int len;
-    char *str;
+    const char *str;
 
     if (objPtr == NULL) {
 	/*
@@ -578,7 +578,7 @@ SvFromTclObj(pTHX_ Tcl_Obj *objPtr)
 	}
     }
     else if (objPtr->typePtr == tclByteArrayTypePtr) {
-	str = (char *) Tcl_GetByteArrayFromObj(objPtr, &len);
+	str = (const char *) Tcl_GetByteArrayFromObj(objPtr, &len);
 	sv = newSVpvn(str, len);
     }
     else if (objPtr->typePtr == tclListTypePtr) {
@@ -1721,7 +1721,7 @@ as_string(SV* sv,...)
     PREINIT:
 	Tcl_Obj* objPtr;
 	int len;
-	char *str;
+	const char *str;
     CODE:
 	objPtr = TclObjFromSv(aTHX_ sv);
 	Tcl_IncrRefCount(objPtr);

--- a/Tcl.xs
+++ b/Tcl.xs
@@ -1706,6 +1706,10 @@ Tcl_UnsetVar2(interp, varname1, varname2, flags = 0)
     OUTPUT:
 	RETVAL
 
+int
+Tcl_InterpDeleted(interp)
+	Tcl interp
+
 
 MODULE = Tcl		PACKAGE = Tcl::List
 
@@ -1865,7 +1869,6 @@ BOOT:
 	newCONSTSUB(stash, "TRACE_WRITES",     newSViv(TCL_TRACE_WRITES));
 	newCONSTSUB(stash, "TRACE_UNSETS",     newSViv(TCL_TRACE_UNSETS));
 	newCONSTSUB(stash, "TRACE_DESTROYED",  newSViv(TCL_TRACE_DESTROYED));
-	newCONSTSUB(stash, "INTERP_DESTROYED", newSViv(TCL_INTERP_DESTROYED));
 	newCONSTSUB(stash, "LEAVE_ERR_MSG",    newSViv(TCL_LEAVE_ERR_MSG));
 	newCONSTSUB(stash, "TRACE_ARRAY",      newSViv(TCL_TRACE_ARRAY));
 

--- a/t/constants.t
+++ b/t/constants.t
@@ -19,7 +19,6 @@ ok(Tcl::GLOBAL_ONLY      |
    Tcl::TRACE_WRITES     |
    Tcl::TRACE_UNSETS     |
    Tcl::TRACE_DESTROYED  |
-   Tcl::INTERP_DESTROYED |
    Tcl::LEAVE_ERR_MSG    |
    Tcl::TRACE_ARRAY,
-   0xBFF);
+   0xAFF);

--- a/t/info.t
+++ b/t/info.t
@@ -27,6 +27,6 @@ if ($^O eq 'cygwin') {
 ok($tcl->Eval("info exists tcl_platform"), 1);
 
 my $tclversion = $tcl->Eval("info tclversion");
-ok($tclversion, qr/^8\.\d+$/);
+ok($tclversion, qr/^\d+\.\d+$/);
 ok(substr($tcl->Eval("info patchlevel"), 0, length($tclversion)), $tclversion);
 ok(length($tcl->Eval("info patchlevel")) > length($tclversion));

--- a/t/svfromtclobj.t
+++ b/t/svfromtclobj.t
@@ -1,0 +1,98 @@
+# Ensure SvFromTclObj() behaves correctly,
+# particularly for Tcl 8.7/9.0 which merged int/wideInt types
+# and unregistered various types.
+
+use warnings;
+use strict;
+use Config;
+use Test;
+
+# Can manually check Devel::Peek::Dump() output for correct SV types
+sub D_P_Dump {
+    if (@ARGV) {
+        require Devel::Peek;
+        Devel::Peek::Dump(@_);
+    }
+}
+
+BEGIN { plan tests => 6; }
+
+use Tcl;
+
+my $i = new Tcl;
+
+
+# Assume $Config{'charbits'} == 8
+my $ivbits = 8 * $Config{'ivsize'};
+
+print STDERR "# IV/UV is $ivbits-bit\n" if (@ARGV);
+
+# Negative integer representable by IV
+my $p_ivmin = -int(2**($ivbits - 1));
+D_P_Dump $p_ivmin;
+my $t_ivmin = $i->Eval("expr {$p_ivmin}");
+D_P_Dump $t_ivmin;
+ok($t_ivmin, $p_ivmin);
+
+# Postive integer representable by UV (but not IV)
+my $p_uvmax = int(2**($ivbits) - 1);
+D_P_Dump $p_uvmax;
+my $t_uvmax = $i->Eval("expr {$p_uvmax}");
+D_P_Dump $t_uvmax;
+ok($t_uvmax, $p_uvmax);
+
+# Negative integer not representable by IV
+# (Perl will use NV, result from Tcl will be PV)
+my $p_below_ivmin = int($p_ivmin - 1);
+D_P_Dump $p_below_ivmin;
+my $t_below_ivmin = $i->Eval("expr {$p_below_ivmin}");
+D_P_Dump $t_below_ivmin;
+ok($t_below_ivmin, $p_below_ivmin);
+
+# Positive integer not representable by UV
+# (Perl will use NV, result from Tcl will be PV)
+my $p_above_uvmax = int($p_uvmax + 1);
+D_P_Dump $p_above_uvmax;
+my $t_above_uvmax = $i->Eval("expr {$p_above_uvmax}");
+D_P_Dump $t_above_uvmax;
+ok($t_above_uvmax, $p_above_uvmax);
+
+
+# Check that string booleans (i.e. "yes"/"no"/"true"/"false"/"on"/"off")
+# are returned as 0 or 1
+{
+
+    $i->Eval(<<'EOS');
+
+# Start with pure string type
+set trueVar true
+
+# Command which reliably causes trueVar to become a boolean type
+# (maybe there is a better way to do so)
+expr {!$trueVar}
+
+EOS
+
+    # Can manually check type (requires Tcl 8.6 or later)
+    $i->Eval(<<'EOS') if (@ARGV);
+catch {puts "# [::tcl::unsupported::representation $trueVar]"}
+EOS
+
+    ok($i->GetVar('trueVar'), 1);
+}
+
+
+# Check bytearray
+{
+    # Command which returns a bytearray
+    # (e.g. one whose contents are not valid UTF-8)
+    my $hexdata = 'e08080ff';
+    my $bytearraycmd = "binary decode hex $hexdata";
+
+    # Can manually check type (requires Tcl 8.6 or later)
+    $i->Eval(<<"EOS") if (@ARGV);
+catch {puts "# [::tcl::unsupported::representation [$bytearraycmd]]"}
+EOS
+
+    ok(join('', (unpack 'H*', $i->Eval($bytearraycmd))), $hexdata);
+}

--- a/tclcfg.tcl
+++ b/tclcfg.tcl
@@ -1,5 +1,11 @@
 puts "tclsh=[info nameofexecutable]"
 set libdir [info library]
+catch {
+    # As of Tcl 8.7, [info library] is a zipfs path.
+    # Use ::tcl::pkgconfig instead (available in Tcl 8.5 and later),
+    # see https://wiki.tcl-lang.org/page/Finding+out+tclConfig%2Esh
+    set libdir [::tcl::pkgconfig get libdir,install]
+}
 set dirs [list \
 	      [file dirname $libdir] \
 	      [file dirname [file dirname $libdir]] \


### PR DESCRIPTION
`Tcl_GetObjType()` returns `const` as of Tcl 8.6, and Tcl.xs never modifies these structs