### PR TITLE
Remove insure_ptrarray() to simplify tests

### DIFF
--- a/t/disposal-subs-a.t
+++ b/t/disposal-subs-a.t
@@ -222,20 +222,11 @@ sub refcts {
 sub flush_afters{
   my $inter=shift;
   while(1) {  # wait for afters to finish
-    my $info0=insure_ptrarray($inter,'after', 'info');
-    last unless (scalar(@$info0));
+    my @info0=$inter->icall('after', 'info');
+    last unless (scalar(@info0));
     $inter->icall('after', 1000, 'set var fafafa');
     $inter->icall('vwait', 'var'); # will wait for 1 seconds
   }
-}
-
-sub insure_ptrarray{
-  my $inter=shift;
-  my $list = $inter->icall(@_);
-  if (ref($list) ne 'Tcl::List') {  # v1.02
-      $list=[split(' ',$list)];
-      }
-return $list;
 }
 
 package FakeTcl::Code;

--- a/t/disposal-subs-b.t
+++ b/t/disposal-subs-b.t
@@ -69,19 +69,10 @@ sub run_cmd{
 sub flush_afters{
   my $inter=shift;
   while(1) {  # wait for afters to finish
-    my $info0=insure_ptrarray($inter,'after', 'info');
-    last unless (scalar(@$info0));
+    my @info0=$inter->icall('after', 'info');
+    last unless (scalar(@info0));
     $inter->icall('after', 300, 'set var fafafa');
     $inter->icall('vwait', 'var'); # will wait for .3 seconds
   }
 } # flush afters
 
-
-sub insure_ptrarray{
-  my $inter=shift;
-  my $list = $inter->icall(@_);
-  if (ref($list) ne 'Tcl::List') {  # v1.02
-      $list=[split(' ',$list)];
-      }
-return $list;
-}

--- a/t/disposal-subs-c.t
+++ b/t/disposal-subs-c.t
@@ -73,19 +73,10 @@ sub run_cmd{
 sub flush_afters{
   my $inter=shift;
   while(1) {  # wait for afters to finish
-    my $info0=insure_ptrarray($inter,'after', 'info');
-    last unless (scalar(@$info0));
+    my @info0=$inter->icall('after', 'info');
+    last unless (scalar(@info0));
     $inter->icall('after', 300, 'set var fafafa');
     $inter->icall('vwait', 'var'); # will wait for .3 seconds
   }
 } # flush afters
 
-
-sub insure_ptrarray{
-  my $inter=shift;
-  my $list = $inter->icall(@_);
-  if (ref($list) ne 'Tcl::List') {  # v1.02
-      $list=[split(' ',$list)];
-      }
-return $list;
-}

--- a/t/disposal-subs-d.t
+++ b/t/disposal-subs-d.t
@@ -13,7 +13,7 @@ print "1..1\n";
 
   my $inter=Tcl->new();
 
-  my $precmd=insure_ptrarray($inter,'info', 'commands', '::perl::*');
+  my $precmd=[$inter->icall('info', 'commands', '::perl::*')];
 
   my $ct1=0;
   my $sub1=sub{ $ct1++; } ;
@@ -51,7 +51,7 @@ print "1..1\n";
 sub newcmds {
   my $precmd=shift;
   my $print=shift;
-  my $postcmd =insure_ptrarray($inter,'info', 'commands', '::perl::*');
+  my $postcmd =[$inter->icall('info', 'commands', '::perl::*')];
   my %start;
   my $newct=0;
   my @newcmds;
@@ -72,19 +72,10 @@ sub dump_refs {
 sub flush_afters{
   my $inter=shift;
   while(1) {  # wait for afters to finish
-    my $info0=insure_ptrarray($inter,'after', 'info');
-    last unless (scalar(@$info0));
+    my @info0=$inter->icall('after', 'info');
+    last unless (scalar(@info0));
     $inter->icall('after', 300, 'set var fafafa');
     $inter->icall('vwait', 'var'); # will wait for .3 seconds
   }
 } # flush afters
 
-
-sub insure_ptrarray{
-  my $inter=shift;
-  my $list = $inter->icall(@_);
-  if (ref($list) ne 'Tcl::List') {  # v1.02
-      $list=[split(' ',$list)];
-      }
-return $list;
-}

--- a/t/disposal-subs-e.t
+++ b/t/disposal-subs-e.t
@@ -40,7 +40,7 @@ $| = 1;
   exit;
 
 sub runcmd{
-  my $precmd=insure_ptrarray($inter,'info', 'commands', '::perl::*');
+  my $precmd=[$inter->icall('info', 'commands', '::perl::*')];
   $ct=0;
   for my $ii (0..9) {
     my $rand=&$sub1();
@@ -57,7 +57,7 @@ sub runcmd{
 sub newcmds {
  my $precmd=shift;
  my $print=shift;
-my $postcmd =insure_ptrarray($inter,'info', 'commands', '::perl::*');
+my $postcmd =[$inter->icall('info', 'commands', '::perl::*')];
 my %start;
 my $newct=0;
 my @newcmds;
@@ -70,19 +70,10 @@ return $newct,\@newcmds;
 sub flush_afters{
   my $inter=shift;
   while(1) {  # wait for afters to finish
-    my $info0=insure_ptrarray($inter,'after', 'info');
-    last unless (scalar(@$info0));
+    my @info0=$inter->icall('after', 'info');
+    last unless (scalar(@info0));
     $inter->icall('after', 300, 'set var fafafa');
     $inter->icall('vwait', 'var'); # will wait for .3 seconds
   }
 } # flush afters
 
-
-sub insure_ptrarray{
-  my $inter=shift;
-  my $list = $inter->icall(@_);
-  if (ref($list) ne 'Tcl::List') {  # v1.02
-      $list=[split(' ',$list)];
-      }
-return $list;
-}

--- a/t/disposal-subs-f.t
+++ b/t/disposal-subs-f.t
@@ -51,22 +51,12 @@ exit;
 sub flush_afters{
   my $inter=shift;
   while(1) {  # wait for afters to finish
-    my $info0=insure_ptrarray($inter,'after', 'info');
-    last unless (scalar(@$info0));
+    my @info0=$inter->icall('after', 'info');
+    last unless (scalar(@info0));
     $inter->icall('after', 300, 'set var fafafa');
     $inter->icall('vwait', 'var'); # will wait for .3 seconds
   }
 } # flush afters
-
-
-sub insure_ptrarray{
-  my $inter=shift;
-  my $list = $inter->icall(@_);
-  if (ref($list) ne 'Tcl::List') {  # v1.02
-      $list=[split(' ',$list)];
-      }
-return $list;
-}
 
 sub ct_subs {
   my $test=shift;

--- a/t/memleak-a.t
+++ b/t/memleak-a.t
@@ -86,18 +86,10 @@ sub refcts {
 sub flush_afters{
   my $inter=shift;
   while(1) {  # wait for afters to finish
-    my $info0=insure_ptrarray($inter,'after', 'info');
-    last unless (scalar(@$info0));
+    my @info0=$inter->icall('after', 'info');
+    last unless (scalar(@info0));
     $inter->icall('after', 300, 'set var fafafa');
     $inter->icall('vwait', 'var'); # will wait for .3 seconds
   }
 } # flush afters
 
-sub insure_ptrarray{
-  my $inter=shift;
-  my $list = $inter->icall(@_);
-  if (ref($list) ne 'Tcl::List') {  # v1.02
-      $list=[split(' ',$list)];
-      }
-return $list;
-} # insure ptrarray


### PR DESCRIPTION
Tests (added in 936e08774bda2c88ac27212bead7188b359ee980, 357b71b0671b86346c7d0a404cbcccb4dc30706d, and 717743b5bafcb8a21daf9cb55bdd9ad80da6949e) have this subroutine:

```perl
sub insure_ptrarray{
  my $inter=shift;
  my $list = $inter->icall(@_);
  if (ref($list) ne 'Tcl::List') {  # v1.02
      $list=[split(' ',$list)];
      }
return $list;
}
```

I have not located anyone else’s explanation for why this routine was needed, or the relevance of the `v1.02` comment. I presume the subroutine is to deal with how `$inter->icall(…)` etc. in SCALAR context does not return a ref to something ARRAY-like when the Tcl result is an empty list (which is behavior from long before and after 1.02). If the code expects an array, though, then it should just use the simpler approach of `$inter->icall(…)` in LIST context. (And code actually needing to split a stringified Tcl list should set a better example and use `$inter->SplitList(…)` rather than `split(' ', …)`.)


