### PR TITLE
info.t: Use `ok(…, qr/…/)` instead of `ok(… =~ m/…/)`

### DIFF
--- a/t/info.t
+++ b/t/info.t
@@ -27,6 +27,6 @@ if ($^O eq 'cygwin') {
 ok($tcl->Eval("info exists tcl_platform"), 1);
 
 my $tclversion = $tcl->Eval("info tclversion");
-ok($tclversion =~ /^8\.\d+$/);
+ok($tclversion, qr/^8\.\d+$/);
 ok(substr($tcl->Eval("info patchlevel"), 0, length($tclversion)), $tclversion);
 ok(length($tcl->Eval("info patchlevel")) > length($tclversion));


### PR DESCRIPTION
Prefer 2- or 3-argument `ok()` for debugging
See chrstphrchvz/perl-tcl-ptk@724d091

Before:

```
not ok 4
# Failed test 4 in t/info.t at line 30
#  t/info.t line 30 is: ok($tclversion =~ /^8\.\d+$/);
```

After:

```
not ok 4
# Test 4 got: "9.0" (t/info.t at line 30)
#   Expected: "(?^:^8\\.\\d+$)"
#  t/info.t line 30 is: ok($tclversion, qr/^8\.\d+$/);
```