### PR TITLE
Test `create_tcl_sub()` from multiple interpreters

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -8,6 +8,7 @@ Tcl.xs			Tcl extension implementation
 t/call.t		See the 'call' and 'icall' methods
 t/constants.t		See if constants and flags are set up properly
 t/createcmd.t		See if command creation works
+t/createcmd2.t		See if command creation works (multiple interpreters)
 t/eval.t		See if Eval-ish things work
 t/info.t	        See if Tcl info command works
 t/result.t		See if Tcl result protocol works

--- a/t/createcmd2.t
+++ b/t/createcmd2.t
@@ -1,0 +1,25 @@
+use warnings;
+use strict;
+
+use Test;
+BEGIN { plan tests => 3, todo => [2] }
+
+use Tcl;
+
+my $i1 = new Tcl;
+my $i2 = new Tcl;
+
+my $cmd1 = $i1->create_tcl_sub(sub {'foo'}, undef, undef, 'same_cmd_name');
+ok($i1->invoke($cmd1), 'foo');
+
+my $cmd2 = $i2->create_tcl_sub(sub {'bar'}, undef, undef, 'same_cmd_name');
+my $cmd1result;
+eval {
+    $cmd1result = $i1->invoke($cmd1);
+    1;
+} or do {
+    my $err = $@ || 'unknown error';
+    print "# $err";
+};
+ok($cmd1result, 'foo');
+ok($i2->invoke($cmd2), 'bar');


### PR DESCRIPTION
This test currently fails due to #54:
```
1..3 todo 2;
# Running under perl version 5.036001 for darwin
# Current time local: Sun Aug 13 02:45:33 2023
# Current time GMT:   Sun Aug 13 07:45:33 2023
# Using Test.pm version 1.31
ok 1
# Tcl procedure '::perl::CODE(0x7fbeb281da10)' not found at t/createcmd2.t line 18.
not ok 2
# Test 2 got: <UNDEF> (t/createcmd2.t at line 24 *TODO*)
#   Expected: "foo"
#  t/createcmd2.t line 24 is: ok($cmd1result, 'foo');
ok 3
```