### PR TITLE
Tcl.xs: avoid macOS 13 SDK deprecation warnings

### DIFF
--- a/Tcl.xs
+++ b/Tcl.xs
@@ -76,6 +76,7 @@ static char defaultLibraryDir[sizeof(LIB_RUNTIME_DIR)+200] = LIB_RUNTIME_DIR;
 
 #elif defined(__APPLE__)
 
+#ifdef SEE_TICKET_125664 /*sorry, no replacement for deprecated function */
 #include <CoreServices/CoreServices.h>
 
 static short DOMAINS[] = {
@@ -85,6 +86,7 @@ static short DOMAINS[] = {
     kSystemDomain
 };
 static const int DOMAINS_LEN = sizeof(DOMAINS)/sizeof(DOMAINS[0]);
+#endif
 
 #elif defined(__hpux)
 /* HPUX requires shl_* routines */


### PR DESCRIPTION
The header section of Tcl.xs uses constants which have been deprecated since macOS 10.8, but only cause warnings to be emitted as of the macOS 13.0 SDK:
```
Tcl.xs:82:5: warning: 'kUserDomain' is deprecated: first deprecated in macOS 10.8 - Deprecated [-Wdeprecated-declarations]
    kUserDomain,
    ^
/Library/Developer/CommandLineTools/SDKs/MacOSX13.1.sdk/System/Library/Frameworks/CoreServices.framework/Frameworks/CarbonCore.framework/Headers/Folders.h:63:1: note: '' has been explicitly marked deprecated here
enum {
^
Tcl.xs:83:5: warning: 'kLocalDomain' is deprecated: first deprecated in macOS 10.8 - Deprecated [-Wdeprecated-declarations]
    kLocalDomain,
    ^
/Library/Developer/CommandLineTools/SDKs/MacOSX13.1.sdk/System/Library/Frameworks/CoreServices.framework/Frameworks/CarbonCore.framework/Headers/Folders.h:63:1: note: '' has been explicitly marked deprecated here
enum {
^
Tcl.xs:84:5: warning: 'kNetworkDomain' is deprecated: first deprecated in macOS 10.8 - Deprecated [-Wdeprecated-declarations]
    kNetworkDomain,
    ^
/Library/Developer/CommandLineTools/SDKs/MacOSX13.1.sdk/System/Library/Frameworks/CoreServices.framework/Frameworks/CarbonCore.framework/Headers/Folders.h:63:1: note: '' has been explicitly marked deprecated here
enum {
^
Tcl.xs:85:5: warning: 'kSystemDomain' is deprecated: first deprecated in macOS 10.8 - Deprecated [-Wdeprecated-declarations]
    kSystemDomain
    ^
/Library/Developer/CommandLineTools/SDKs/MacOSX13.1.sdk/System/Library/Frameworks/CoreServices.framework/Frameworks/CarbonCore.framework/Headers/Folders.h:63:1: note: '' has been explicitly marked deprecated here
enum {
^
4 warnings generated.
```

These constants and the <CoreServices/CoreServices.h> header file were only needed by code which was disabled in 8935cbb97e5d74210cd4397e6c6ccffa792fc054 for https://rt.cpan.org/Public/Bug/Display.html?id=125664
So for consistency I propose disabling this header section code as well.

Also, given the other effects of including <CoreServices/CoreServices.h> as described in https://github.com/gisle/tcl.pm/issues/43#issuecomment-1093050426, not always including  <CoreServices/CoreServices.h> may prevent other issues from being encountered.